### PR TITLE
Fix clean to remove libmdbm.so.4, and the CPP_EXES

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -133,7 +133,7 @@ $(OBJDIR)/%.o: %.cc
 #	$(CC) $(CFLAGS) $(PEDANTIC) -c $< -o $@
 
 # TODO ensure we have all gcov generated files
-CLEAN_OBJECTS=*.o *.d *.lib *.so *.xml *.gcov *.gcda
+CLEAN_OBJECTS=*.o *.d *.lib *.so.* *.xml *.gcov *.gcda
 CLEAN_OB_DIRS=. $(OBJDIR_BASE) $(OBJDIR_PROF)
 .PHONY: clean-objs
 clean-objs:

--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -60,7 +60,7 @@ $(foreach exe, $(EXE), $(eval $(call ExeTargetRules,$(exe))))
 $(foreach exe, $(CPP_EXE), $(eval $(call CppExeTargetRules,$(exe))))
 
 clean :: clean-objs clean-exe-mash clean-exe-mdbm_bench clean-exe-mdbm_import \
-  $(foreach exe, $(EXE), clean-exe-$(exe))
+  $(foreach exe, $(EXE), clean-exe-$(exe)) $(foreach exe, $(CPP_EXE), clean-exe-$(exe))
 
 EXE_DEST=$(BIN_PREFIX)
 install:: build-exes


### PR DESCRIPTION
Clean was leaving these behind:

./src/tools/object/mdbm_config
./src/tools/object/mdbm_export_splitter
./src/lib/object/libmdbm.so.4
