### PR TITLE
Explicitly link C++ stdlib preventing linking issues for straight C user...

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -18,7 +18,7 @@ COMP_FLAGS += -DUSE_OPENSSL
 COMP_FLAGS += -DALLOW_MLOCK_RESET -DHAVE_ROBUST_PTHREADS
 # readline support is for mash only
 LINK_READLINE=-lreadline
-LDADD += -lm -lpthread -lcrypto
+LDADD += -lm -lpthread -lcrypto -lstdc++
 LIBDIR=/usr/local/lib64
 INCDIR=/usr/local/include
 PERL=perl


### PR DESCRIPTION
If -lstdc++ isn't explicitly linked then the resulting mdbm.so will have linker errors if used with a plain C compiler (versus say g++). mdbm.so really does depend on stdc++ so it should link it explicitly.