### PR TITLE
OSX build updates, static inline to allow -O0

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -27,7 +27,11 @@ endif
 # readline support is for mash only
 LINK_READLINE=-lreadline
 LDADD += -lm -lpthread -lcrypto -lstdc++
+ifeq ($(UNAME), Linux)
 LIBDIR=/usr/local/lib64
+else
+LIBDIR=/usr/local/lib
+endif
 INCDIR=/usr/local/include
 PERL=perl
 TRUECMD=true # not /bin/true on OSX
@@ -106,7 +110,7 @@ else
   OBJDIR=$(OBJDIR_BASE)
 endif
 LOCAL_LDADD = -L$(TOPDIR)/src/lib/$(OBJDIR)
-COMP_FLAGS +=  -g -O2 -I/usr/include -I$(INCDIR) -I$(TOPDIR)/include -I. -Wall -fPIC 
+COMP_FLAGS +=  -g -O2 -I/usr/include -I$(INCDIR) -I$(TOPDIR)/include -I. -Wall -fPIC
 
 # get gcc version (space-separated components)
 GCC_VER_SPC=$(shell gcc -dumpversion | tr '.' ' ')

--- a/src/lib/atomic.h
+++ b/src/lib/atomic.h
@@ -98,7 +98,7 @@ static inline uint32_t gettid() {
   /* and some OS don't expose any other unique id. */
   /* xor-fold pthread_self() pointer down to 16-bits */
   uint32_t tid;
-  uint64_t pself = pthread_self();
+  uint64_t pself = (uint64_t)pthread_self();
   pself = pself ^ (pself >> 32);
   pself = pself ^ (pself >> 16);
   /* add in PID to help unique-ify */

--- a/src/lib/mdbm.c
+++ b/src/lib/mdbm.c
@@ -129,7 +129,7 @@ static int mdbm_set_window_size_internal(MDBM* db, size_t wsize);
 
 extern int do_delete_lockfiles(const char* dbname);
 
-inline uint64_t
+static inline uint64_t
 get_gtod_usec()
 {
     struct timeval tv;
@@ -145,7 +145,7 @@ volatile static uint64_t tsc_per_usec;    /* TSC clock cycles per microsecond */
 
 /* Intel (and later model AMD) Fetch Time-StampCounter
  * WANRING:  This value may be affected by speedstep and may vary randomly across cores. */
-__inline__ uint64_t rdtsc(void)
+static inline uint64_t rdtsc(void)
 {
     uint32_t lo, hi;
     /* We cannot use "=A", since this would use %rax on x86_64 and

--- a/src/test/func-test/Makefile
+++ b/src/test/func-test/Makefile
@@ -28,7 +28,7 @@ TESTS=                       \
   replace-func-stress-test
 
 
-MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm
+MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm -L$(LIBDIR)
 MYLIBS += -lpthread $(LIBRT) -lstdc++ -lcppunit 
 LD_EXTRA += $(MYLIBS) -lcppunit $(LOCAL_LDADD)
 CXXFLAGS += -I$(TOPDIR)/src/lib

--- a/src/test/pool_test/Makefile
+++ b/src/test/pool_test/Makefile
@@ -15,7 +15,7 @@ TESTS=                       \
   test_ccmp
 
 
-MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm
+MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm -L$(LIBDIR)
 MYLIBS += -lpthread $(LIBRT) -lstdc++ -lreadline -lcppunit 
 LD_EXTRA += $(MYLIBS) -lcppunit $(LOCAL_LDADD)
 CXXFLAGS += -I$(TOPDIR)/src/lib

--- a/src/test/smoke-test/Makefile
+++ b/src/test/smoke-test/Makefile
@@ -19,7 +19,7 @@ TESTS=                       \
   test_lock   
 
 
-MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm
+MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm -L$(LIBDIR)
 MYLIBS += -lpthread $(LIBRT) -lstdc++ -lreadline -lcppunit 
 LD_EXTRA += $(MYLIBS) -lcppunit $(LOCAL_LDADD)
 CXXFLAGS += -I$(TOPDIR)/src/lib

--- a/src/test/unit-test/Makefile
+++ b/src/test/unit-test/Makefile
@@ -55,8 +55,8 @@ TESTS+=                       \
   test_lockv3                \
 
 
-MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm
-MYLIBS += -lpthread $(LIBRT) -lstdc++ -lreadline -lcppunit 
+MYLIBS =  -L$(TOPDIR)/src/lib/$(OBJDIR) -lmdbm -L$(LIBDIR)
+MYLIBS += -lpthread $(LIBRT) -lstdc++ -lreadline -lcppunit
 LD_EXTRA += $(MYLIBS) -lcppunit $(LOCAL_LDADD)
 CXXFLAGS += -I$(TOPDIR)/src/lib
 

--- a/src/tools/mdbm_export.c
+++ b/src/tools/mdbm_export.c
@@ -62,7 +62,7 @@ static void do_cdbdump(MDBM *db, FILE *fp)
   fputc('\n', fp);
 }
 
-inline void dump_str(datum d, FILE *fp)
+static inline void dump_str(datum d, FILE *fp)
 {
   int i;
 


### PR DESCRIPTION
Small build tweaks. Ran into some further issues and needed to build -O0, which isn't possible with pure "inline." static inline should work, per: http://www.greenend.org.uk/rjk/tech/inline.html.

Separate PR to follow re the other runtime issues. With this PR I can build successfully.