### PR TITLE
fix null pointer dereference on non-linux

### DIFF
--- a/src/lib/mdbm.c
+++ b/src/lib/mdbm.c
@@ -3608,7 +3608,9 @@ check_hugetlbfs(const char *filename, int fd, int *hugep, uint32_t *page_size)
 #else
     rc = 1;
     *hugep = 0;
-    *page_size = 0;
+    if (page_size != NULL) {
+        *page_size = 0;
+    }
 #endif
     return rc;
 }


### PR DESCRIPTION
It appears to me this codepath can't have ever worked on non-linux. This function is only ever called with a NULL page_size. How was this working on FreeBSD? I'm worried I'm missing something.