### PR TITLE
Apply patch from Yahoo! Japan.

### DIFF
--- a/src/java/com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
+++ b/src/java/com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
@@ -579,20 +579,18 @@ static jobject mdbm_fetch_wrapper(JNIEnv *jenv, jclass thisClass,
     datum value = { 0, };
     int ret = (*mdbm_function)(mdbm, keyDatum.getDatum(), &value, iter);
 
-    // deal with errors first.
-    if (false
-            == checkZeroIsOkReturn(jenv, ret, thisObject, MDBM_FETCH_EXCEPTION,
+    if ( ret == -1 ) {
+        if ( errno == ENOENT ) {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_NOENTRY_EXCEPTION,
+                    mdbmNoEntryExceptionClass, mdbmNoEntryExceptionCtorId,
+                    mdbm_function_name, 0, iter);
+            return NULL;
+        } else {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_FETCH_EXCEPTION,
                     mdbmFetchExceptionClass, mdbmFetchExceptionCtorId,
-                    mdbm_function_name, 0, iter)) {
-        return NULL;
-    }
-
-    // deal with missing entry
-    if (0 == value.dsize && NULL == value.dptr) {
-        checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_NOENTRY_EXCEPTION,
-                mdbmNoEntryExceptionClass, mdbmNoEntryExceptionCtorId,
-                mdbm_function_name, 0, iter);
-        return NULL;
+                    mdbm_function_name, 0, iter);
+            return NULL;
+        }
     }
 
     // deal with success.

--- a/src/java/src/main/java/com/yahoo/db/mdbm/MdbmInterface.java
+++ b/src/java/src/main/java/com/yahoo/db/mdbm/MdbmInterface.java
@@ -138,29 +138,27 @@ public interface MdbmInterface extends Closeable {
 
     /**
      * Fetches the record specified by the <em>key</em> argument. If such a record exists in the database, the size and
-     * location are stored in the datum pointed to by val. If no matching record exists, a null datum (dsize==0,
-     * dptr==NULL) is returned. <br>
-     * 
-     * <b> Unlike the underlying mdbm_fetch function, this will lock the mdbm using mdbm_smart_lock while copying the
-     * data out</b>
-     * 
+     * location are stored in the datum pointed to by val. If no matching record exists, a MdbmNoEntryException is thrown.
+     * <br>
      * <b> Unlike the underlying mdbm_fetch function, this does not allow in place updates of the data.</b>
      * 
-     * @param key ptr to @see datum used as the index key
+     * @param key ptr to @see MdbmDatum used as the index key
      * @param iter MDBM Iterator (see @see MdbmIterator)
-     * @return null when not found
+     * @return MdbmDatum stored value.
+     * @throws MdbmNoEntryException no matching recoed exists.
      * @throws MdbmException upon error.
      */
     MdbmDatum fetch(MdbmDatum key, MdbmIterator iter) throws MdbmException;
 
     /**
      * fetches the record specified by the <em>key</em> argument. If such a record exists in the database, the size and
-     * location are stored in the datum pointed to by val. If no matching record exists, a null datum (dsize==0,
-     * dptr==NULL) is returned. <br>
+     * location are stored in the datum pointed to by val. If no matching record exists, a MdbmNoEntryException is thrown.
+     * <br>
      * <b> Unlike the underlying mdbm_fetch function, this does not allow in place updates of the data.</b>
      * 
      * @param key ptr to @see datum used as the index key
-     * @return null when not found
+     * @return MdbmDatum stored value.
+     * @throws MdbmNoEntryException no matching recoed exists.
      * @throws MdbmException upon error.
      */
     MdbmDatum fetch(MdbmDatum key) throws MdbmException;

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
@@ -165,6 +165,21 @@ public abstract class TestSimpleMdbm {
         }
     }
 
+    @Test(expectedExceptions = { MdbmNoEntryException.class })
+    public void testFetchNoEntry() throws MdbmException, UnsupportedEncodingException {
+        String key = "nothere";
+        MdbmDatum datum = new MdbmDatum(key.getBytes("UTF-8"));
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(fetchMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                                            | Open.MDBM_O_CREAT, 0755, 0, 0);
+            MdbmDatum data = mdbm.fetch(datum, mdbm.iterator());
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
     @Test
     public void testFetchWithoutIterator() throws MdbmException, UnsupportedEncodingException {
         String key = "testkey";


### PR DESCRIPTION
Hello team,

I'm Hiroyuki, an engineer in Yahoo! JAPAN.

I found a bug of yjava_mdbm.
The fetch() method doesn't throw MdbmNoEntryException when no record is found.
(It throws MdbmFetchException.)

I have attached a test code reproducing the problem
and patches to fix it.

Please confirm these patches and fix the problem.

Thank you and best regards,

--
Hiroyuki KATO