### PR TITLE
Fix NoClassDefFoundError and make delete methods throw MdbmNoEntryException

### DIFF
--- a/src/java/com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
+++ b/src/java/com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
@@ -68,6 +68,9 @@ DECLARE_CACHED_METHOD_ID(mdbmExceptionClass, mdbmExceptionCtorId, "<init>", "(Lj
 DECLARE_CACHED_METHOD_ID(mdbmExceptionClass, mdbmExceptionSetPathId, "setPath", "(Ljava/lang/String;)V")
 DECLARE_CACHED_METHOD_ID(mdbmExceptionClass, mdbmExceptionSetInfoId, "setInfo", "(Ljava/lang/String;)V")
 
+DECLARE_CACHED_CLASS(mdbmDeleteExceptionClass, MDBM_DELETE_EXCEPTION)
+DECLARE_CACHED_METHOD_ID(mdbmDeleteExceptionClass, mdbmDeleteExceptionCtorId, "<init>", "(Ljava/lang/String;)V")
+
 DECLARE_CACHED_CLASS(mdbmFetchExceptionClass, MDBM_FETCH_EXCEPTION)
 DECLARE_CACHED_METHOD_ID(mdbmFetchExceptionClass, mdbmFetchExceptionCtorId, "<init>", "(Ljava/lang/String;)V")
 
@@ -806,9 +809,17 @@ JNIEXPORT void JNICALL Java_com_yahoo_db_mdbm_internal_NativeMdbmAccess_mdbm_1de
 
     int ret = mdbm_delete (mdbm, *keyDatum.getDatum());
 
-    // deal with errors first.
-    checkZeroIsOkReturn(jenv, ret, MDBM_DELETE_EXCEPTION, "mdbm_delete", 0,
-            NULL);
+    if ( ret == -1 ) {
+        if ( errno == ENOENT ) {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_NOENTRY_EXCEPTION,
+                    mdbmNoEntryExceptionClass, mdbmNoEntryExceptionCtorId,
+                    "mdbm_delete", 0, NULL);
+        } else {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_DELETE_EXCEPTION,
+                    mdbmDeleteExceptionClass, mdbmDeleteExceptionCtorId,
+                    "mdbm_delete", 0, NULL);
+        }
+    }
 }
 
 /*
@@ -827,9 +838,17 @@ JNIEXPORT void JNICALL Java_com_yahoo_db_mdbm_internal_NativeMdbmAccess_mdbm_1de
 
     int ret = mdbm_delete_r (mdbm, iter);
 
-    // deal with errors first.
-    checkZeroIsOkReturn(jenv, ret, MDBM_DELETE_EXCEPTION, "mdbm_delete_r", 0,
-            iter);
+    if ( ret == -1 ) {
+        if ( errno == ENOENT ) {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_NOENTRY_EXCEPTION,
+                    mdbmNoEntryExceptionClass, mdbmNoEntryExceptionCtorId,
+                    "mdbm_delete_r", 0, iter);
+        } else {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_DELETE_EXCEPTION,
+                    mdbmDeleteExceptionClass, mdbmDeleteExceptionCtorId,
+                    "mdbm_delete_r", 0, iter);
+        }
+    }
 }
 
 /*
@@ -1239,9 +1258,17 @@ JNIEXPORT void JNICALL Java_com_yahoo_db_mdbm_internal_NativeMdbmAccess_mdbm_1de
 
     int ret = mdbm_delete_str(mdbm, keyString.getChars());
 
-    // deal with errors first.
-    checkZeroIsOkReturn(jenv, ret, MDBM_DELETE_EXCEPTION,
-            "mdbm_delete_str", 0, NULL);
+    if ( ret == -1 ) {
+        if ( errno == ENOENT ) {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_NOENTRY_EXCEPTION,
+                    mdbmNoEntryExceptionClass, mdbmNoEntryExceptionCtorId,
+                    "mdbm_delete_str", 0, NULL);
+        } else {
+            checkZeroIsOkReturn(jenv, -1, thisObject, MDBM_DELETE_EXCEPTION,
+                    mdbmDeleteExceptionClass, mdbmDeleteExceptionCtorId,
+                    "mdbm_delete_str", 0, NULL);
+        }
+    }
 
 }
 

--- a/src/java/src/main/java/com/yahoo/db/mdbm/exceptions/MdbmDeleteException.java
+++ b/src/java/src/main/java/com/yahoo/db/mdbm/exceptions/MdbmDeleteException.java
@@ -1,0 +1,13 @@
+package com.yahoo.db.mdbm.exceptions;
+
+public class MdbmDeleteException extends MdbmException {
+    private static final long serialVersionUID = 1L;
+
+    public MdbmDeleteException() {
+        super();
+    }
+
+    public MdbmDeleteException(String message) {
+        super(message);
+    }
+}

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestExceptions.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestExceptions.java
@@ -6,6 +6,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.db.mdbm.exceptions.InvalidMdbmParametersException;
 import com.yahoo.db.mdbm.exceptions.MdbmException;
+import com.yahoo.db.mdbm.exceptions.MdbmDeleteException;
 import com.yahoo.db.mdbm.exceptions.MdbmFetchException;
 import com.yahoo.db.mdbm.exceptions.MdbmIllegalOperationException;
 import com.yahoo.db.mdbm.exceptions.MdbmInvalidStateException;
@@ -70,6 +71,9 @@ public class TestExceptions {
         e = new SharedLockViolationException("message");
         e = new SharedLockViolationException(e);
         e = new SharedLockViolationException("message", e);
+
+        e = new MdbmDeleteException();
+        e = new MdbmDeleteException("message");
 
         e = new MdbmFetchException();
         e = new MdbmFetchException("message");

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
@@ -22,6 +22,7 @@ import com.yahoo.db.mdbm.Open;
 import com.yahoo.db.mdbm.Store;
 import com.yahoo.db.mdbm.exceptions.MdbmException;
 import com.yahoo.db.mdbm.exceptions.MdbmNoEntryException;
+import com.yahoo.db.mdbm.exceptions.MdbmDeleteException;
 
 public abstract class TestSimpleMdbm {
     public static final String testMdbmV3Path = "test/resources/testv3.mdbm";
@@ -29,6 +30,8 @@ public abstract class TestSimpleMdbm {
     public static final String fetchMdbmV3Path = "target/fetch_testv3.mdbm";
     public static final String fetchMdbmV3PathSingleArch = "target/fetch_testv3_single_arch.mdbm";
     public static final String iteratorMdbmV3PathA = "target/iterator_testv3.mdbm";
+    public static final String emptyMdbmV3Path = "target/empty_testv3.mdbm";
+    public static final String deleteMdbmV3Path = "target/delete_testv3.mdbm";
 
     @Test(dataProvider = "createMdbms")
     public static MdbmInterface testCreate(String path, int flags, boolean close) throws MdbmException {
@@ -197,6 +200,134 @@ public abstract class TestSimpleMdbm {
             Assert.assertNotNull(data);
             Assert.assertNotNull(data.getData());
             Assert.assertEquals(new String(data.getData()), key);
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+
+    @Test
+    public void testDeleteString() throws MdbmException, UnsupportedEncodingException {
+        String key = "key_for_delete_string";
+        String value = "value_for_delete_string";
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(deleteMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+
+            mdbm.storeString(key, value, Store.MDBM_REPLACE);
+            String ret = mdbm.fetchString(key);
+            Assert.assertEquals(ret, value);
+
+            mdbm.deleteString(key);
+            String ret2 = mdbm.fetchString(key);
+            Assert.assertNull(ret2);
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+    @Test
+    public void testDelete() throws MdbmException, UnsupportedEncodingException {
+        String key = "key_for_delete";
+        String value = "value_for_delete";
+        MdbmDatum kDatum = new MdbmDatum(key.getBytes("Utf-8"));
+        MdbmDatum vDatum = new MdbmDatum(value.getBytes("Utf-8"));
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(deleteMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+
+            mdbm.store(kDatum, vDatum, Store.MDBM_REPLACE, mdbm.iterator());
+            MdbmDatum ret = mdbm.fetch(kDatum);
+            Assert.assertNotNull(ret);
+            Assert.assertNotNull(ret.getData());
+            Assert.assertEquals(new String(ret.getData()), value);
+
+            mdbm.delete(kDatum);
+            try {
+                mdbm.fetch(kDatum); // throws MdbmNoEntryException
+                Assert.fail();
+            } catch (MdbmNoEntryException e) {
+                // expected. ok.
+            }
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+    @Test
+    public void testDeleteIterator() throws MdbmException, UnsupportedEncodingException {
+        String key = "key_for_delete_iterator";
+        String value = "value_for_delete_iterator";
+        MdbmDatum kDatum = new MdbmDatum(key.getBytes("Utf-8"));
+        MdbmDatum vDatum = new MdbmDatum(value.getBytes("Utf-8"));
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(deleteMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+
+            mdbm.store(kDatum, vDatum, Store.MDBM_REPLACE, mdbm.iterator());
+            MdbmIterator iter = mdbm.iterator();
+            MdbmDatum ret = mdbm.fetch(kDatum, iter);
+            Assert.assertNotNull(ret);
+            Assert.assertNotNull(ret.getData());
+            Assert.assertEquals(new String(ret.getData()), value);
+
+            mdbm.delete(iter);
+            try {
+                mdbm.fetch(kDatum); // throws MdbmNoEntryException
+                Assert.fail();
+            } catch (MdbmNoEntryException e) {
+                // expected. ok.
+            }
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+    @Test(expectedExceptions = { MdbmDeleteException.class })
+    public void testDeleteStringNoEntry() throws MdbmException, UnsupportedEncodingException {
+        String key = "nothere";
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(deleteMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+            mdbm.deleteString(key);
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+    @Test(expectedExceptions = { MdbmDeleteException.class })
+    public void testDeleteNoEntry() throws MdbmException, UnsupportedEncodingException {
+        String key = "nothere";
+        MdbmDatum datum = new MdbmDatum(key.getBytes("UTF-8"));
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(deleteMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+            mdbm.delete(datum);
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+    @Test(expectedExceptions = { MdbmDeleteException.class })
+    public void testDeleteIteratorNoEntry() throws MdbmException, UnsupportedEncodingException {
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+
+            MdbmIterator iter = mdbm.iterator();
+            mdbm.delete(iter);
         } finally {
             if (null != mdbm)
                 mdbm.close();


### PR DESCRIPTION
In java implementation,

NoClassDefFoundError occurs when deleteing non existing key.

```
testDeleteNoEntry(com.yahoo.db.mdbm.TestV4)  Time elapsed: 0.023 sec  <<< FAILURE!
java.lang.NoClassDefFoundError: com/yahoo/db/mdbm/exceptions/MdbmDeleteException
        at com.yahoo.db.mdbm.internal.NativeMdbmAccess.mdbm_delete(Native Method)
        at com.yahoo.db.mdbm.internal.NativeMdbmImplementation.delete(NativeMdbmImplementation.java:99)
        at com.yahoo.db.mdbm.TestSimpleMdbm.testDeleteNoEntry(TestSimpleMdbm.java:214)
```

This PR implements 2 points.
- Define MdbmDeleteException.
- Make delete methods throw MdbmNoEntryException when key is not exists.
