### PR TITLE
Fix segfault when storing large objects to lru cache

### DIFF
--- a/src/lib/mdbm.c
+++ b/src/lib/mdbm.c
@@ -5148,7 +5148,7 @@ mdbm_store_r(MDBM *db, datum* key, datum* val, int flags, MDBM_ITER* iter)
                     pnum = hashval_to_pagenum(db,h);
                     p = pagenum_to_page(db,pnum,MDBM_PAGE_EXISTS,MDBM_PAGE_MAP);
                 }
-                if (free_bytes >= alloc_bytes) {
+                if (free_bytes >= alloc_bytes && ntries < MAX_TRIES) {
                     continue;
                 }
             }


### PR DESCRIPTION
In the following conditions, _alloc_lob_ variable is NULL.
* free_bytes >= alloc_bytes
* ntries == 100
