### PR TITLE
fix a bug that mdbm.first(iter) always return NULL in Java implementation

### DIFF
--- a/src/java/com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
+++ b/src/java/com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
@@ -328,12 +328,12 @@ public:
     }
 
     // FETCH
-    ScopedKvPair(JNIEnv *jenv, kvpair &kv) :
+    ScopedKvPair(JNIEnv *jenv, kvpair &in_kv) :
             valid(false), mdbmKvPair(NULL) {
         zeroKv(kv);
 
-        if ((0 == kv.key.dsize || NULL == kv.key.dptr)
-                && (0 == kv.val.dsize || NULL == kv.val.dptr)) {
+        if ((0 == in_kv.key.dsize || NULL == in_kv.key.dptr)
+                && (0 == in_kv.val.dsize || NULL == in_kv.val.dptr)) {
             //nothing to do.
             return;
         }
@@ -346,10 +346,10 @@ public:
         }
 
         // now we need to create the datums to fill out.
-        key.setDatum(jenv, kv.key);
+        key.setDatum(jenv, in_kv.key);
         RETURN_IF_EXCEPTION_OR_NULL(key.getMdbmDatum());
 
-        val.setDatum(jenv, kv.val);
+        val.setDatum(jenv, in_kv.val);
         RETURN_IF_EXCEPTION_OR_NULL(val.getMdbmDatum());
 
         // now that key and val are setup, we can create the java object using them.

--- a/src/java/jni_helper_defines.h
+++ b/src/java/jni_helper_defines.h
@@ -43,7 +43,7 @@
 #ifdef JAVA_DEBUG_TYPEMAPS
 #undef NDEBUG
 #include <assert.h>
-#endif JAVA_DEBUG_TYPEMAPS
+#endif //JAVA_DEBUG_TYPEMAPS
 
 #define POINTER_TO_CONTEXT(CTX_TYPE) CTX_TYPE* context= reinterpret_cast<CTX_TYPE*>(pointer);
 #define CONTEXT_TO_POINTER(CTX) jlong pointer = reinterpret_cast<jlong>(CTX);

--- a/src/java/src/main/java/com/yahoo/db/mdbm/MdbmInterface.java
+++ b/src/java/src/main/java/com/yahoo/db/mdbm/MdbmInterface.java
@@ -538,11 +538,11 @@ public interface MdbmInterface extends Closeable {
     /**
      * fetch first record
      * 
-     * Initializes the iterator, and returns the first key/value pair from the db. Subsequent calls to mdbm_next_r() or
-     * mdbm_nextkey_r() with this iterator will loop through the entire db.
+     * Initializes the iterator, and returns the first key/value pair from the db. Subsequent calls to next() or
+     * nextKey() with this iterator will loop through the entire db.
      * 
      * @param iter MDBM Iterator (see @see MdbmIterator)
-     * @return kvpair. If db is empty, a null kvpair (key and value dsize==0, dptr==NULL).
+     * @return kvpair. If db is empty, NULL.
      */
     MdbmKvPair first(MdbmIterator iter) throws MdbmException;
 
@@ -552,29 +552,28 @@ public interface MdbmInterface extends Closeable {
      * Returns the next key/value pair from the db, based on the iterator.
      * 
      * @param iter MDBM Iterator (see @see MdbmIterator)
-     * @return kvpair. If end of db is reached, a null kvpair (key and value dsize==0, dptr==NULL).
+     * @return kvpair. If end of db is reached, NULL.
      */
     MdbmKvPair next(MdbmIterator iter) throws MdbmException;
 
     /**
      * fetch first key
      * 
-     * Initializes the iterator, and returns the first key from the db. Subsequent calls to mdbm_next_r() or
-     * mdbm_nextkey_r() with this iterator will loop through the entire db.
+     * Initializes the iterator, and returns the first key from the db. Subsequent calls to next() or
+     * nextKey() with this iterator will loop through the entire db.
      * 
      * @param iter MDBM Iterator (see @see MdbmIterator)
-     * @return datum. If db is empty, a null datum (dsize==0, dptr==NULL).
+     * @return datum. If db is empty, NULL.
      */
     MdbmDatum firstKey(MdbmIterator iter) throws MdbmException;
 
     /**
      * fetch next key
      * 
-     * returns the next key from the db. Subsequent calls to mdbm_next_r() or mdbm_nextkey_r() with this iterator will
-     * loop through the entire db.
-     * 
+     * returns the next key from the db, based on the iterator.
+     *
      * @param iter MDBM Iterator (see @see MdbmIterator)
-     * @return datum. If end of db is reached, a null datum (dsize==0, dptr==NULL).
+     * @return datum. If end of db is reached, NULL.
      * @throws MdbmException
      */
     MdbmDatum nextKey(MdbmIterator iter) throws MdbmException;

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
@@ -134,6 +134,28 @@ public abstract class TestSimpleMdbm {
         }
     }
 
+    @Test
+    public void testEmptyFirstKey() throws MdbmException {
+        MdbmInterface mdbm = null;
+        MdbmIterator iter = null;
+        try {
+            mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_O_RDONLY, 0755, 0, 0);
+            iter = mdbm.iterator();
+
+            Assert.assertNotNull(iter);
+
+            MdbmDatum datum = mdbm.firstKey(iter);
+            Assert.assertNull(datum);
+            datum = mdbm.nextKey(iter);
+            Assert.assertNull(datum);
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+            if (null != iter)
+                iter.close();
+        }
+    }
+
     @Test(dataProvider = "iterateMdbms")
     public void testIterateKeys(String path, int flags)
             throws MdbmException, UnsupportedEncodingException {

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
@@ -39,8 +39,8 @@ public abstract class TestSimpleMdbm {
     @BeforeClass
     public void initEmptyMdbm() throws MdbmException {
         MdbmInterface mdbm = null;
-        mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
-                        | Open.MDBM_O_CREAT, 0755, 0, 0);
+        mdbm = MdbmProvider.open(emptyMdbmV3Path,
+                Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR | Open.MDBM_O_CREAT, 0755, 0, 0);
         mdbm.close();
     }
 
@@ -49,8 +49,8 @@ public abstract class TestSimpleMdbm {
         MdbmInterface mdbm = null;
 
         try {
-            mdbm = MdbmProvider.open(iteratorMdbmV3PathA, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
-                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+            mdbm = MdbmProvider.open(iteratorMdbmV3PathA,
+                    Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR | Open.MDBM_O_CREAT, 0755, 0, 0);
 
             for (int i = 0; i < iterationMax; i++) {
                 String kStr = Integer.toString(i);
@@ -110,12 +110,12 @@ public abstract class TestSimpleMdbm {
         }
     }
 
-    @Test
-    public void testEmptyFirst() throws MdbmException {
+    @Test(dataProvider = "emptyMdbms")
+    public void testEmptyFirst(String path, int flags) throws MdbmException {
         MdbmInterface mdbm = null;
         MdbmIterator iter = null;
         try {
-            mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_O_RDONLY, 0755, 0, 0);
+            mdbm = MdbmProvider.open(path, flags, 0755, 0, 0);
             iter = mdbm.iterator();
 
             Assert.assertNotNull(iter);
@@ -134,12 +134,12 @@ public abstract class TestSimpleMdbm {
         }
     }
 
-    @Test
-    public void testEmptyFirstKey() throws MdbmException {
+    @Test(dataProvider = "emptyMdbms")
+    public void testEmptyFirstKey(String path, int flags) throws MdbmException {
         MdbmInterface mdbm = null;
         MdbmIterator iter = null;
         try {
-            mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_O_RDONLY, 0755, 0, 0);
+            mdbm = MdbmProvider.open(path, flags, 0755, 0, 0);
             iter = mdbm.iterator();
 
             Assert.assertNotNull(iter);

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestSimpleMdbm.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.db.mdbm.Constants;
@@ -32,6 +33,38 @@ public abstract class TestSimpleMdbm {
     public static final String iteratorMdbmV3PathA = "target/iterator_testv3.mdbm";
     public static final String emptyMdbmV3Path = "target/empty_testv3.mdbm";
     public static final String deleteMdbmV3Path = "target/delete_testv3.mdbm";
+
+    public final int iterationMax = 10;
+
+    @BeforeClass
+    public void initEmptyMdbm() throws MdbmException {
+        MdbmInterface mdbm = null;
+        mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                        | Open.MDBM_O_CREAT, 0755, 0, 0);
+        mdbm.close();
+    }
+
+    @BeforeClass
+    public void initIteratorMdbm() throws MdbmException, UnsupportedEncodingException {
+        MdbmInterface mdbm = null;
+
+        try {
+            mdbm = MdbmProvider.open(iteratorMdbmV3PathA, Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR
+                    | Open.MDBM_O_CREAT, 0755, 0, 0);
+
+            for (int i = 0; i < iterationMax; i++) {
+                String kStr = Integer.toString(i);
+                String vStr = Integer.toString(100+i);
+                MdbmDatum kDatum = new MdbmDatum(kStr.getBytes("UTF-8"));
+                MdbmDatum vDatum = new MdbmDatum(vStr.getBytes("UTF-8"));
+                mdbm.store(kDatum, vDatum, 0);
+            }
+
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
 
     @Test(dataProvider = "createMdbms")
     public static MdbmInterface testCreate(String path, int flags, boolean close) throws MdbmException {
@@ -82,7 +115,7 @@ public abstract class TestSimpleMdbm {
         MdbmInterface mdbm = null;
         MdbmIterator iter = null;
         try {
-            mdbm = MdbmProvider.open(testMdbmV3Path, Open.MDBM_O_RDONLY, 0755, 0, 0);
+            mdbm = MdbmProvider.open(emptyMdbmV3Path, Open.MDBM_O_RDONLY, 0755, 0, 0);
             iter = mdbm.iterator();
 
             Assert.assertNotNull(iter);
@@ -102,24 +135,86 @@ public abstract class TestSimpleMdbm {
     }
 
     @Test(dataProvider = "iterateMdbms")
-    public static void testIterate(String path, int flags) throws MdbmException {
+    public void testIterateKeys(String path, int flags)
+            throws MdbmException, UnsupportedEncodingException {
         MdbmInterface mdbm = null;
 
         try {
-            mdbm = testCreate(path, flags, false);
-            int max = 10;
-            for (int i = 0; i < max; i++) {
-                String s = Integer.toString(i);
-                mdbm.storeString(s, s, 0);
+            mdbm = MdbmProvider.open(path, flags, 0755, 0, 0);
+
+            MdbmIterator itr = mdbm.iterator();
+            MdbmDatum datum;
+            String retStr;
+            int sum = 0;
+
+            System.err.println("=== first ===");
+            datum = mdbm.firstKey(itr);
+            Assert.assertNotNull(datum);
+            Assert.assertNotNull(datum.getData());
+            retStr = new String(datum.getData());
+            System.err.println(retStr);
+            sum += Integer.parseInt(retStr);
+            for (int i = 1; i < iterationMax; i++) {
+                System.err.println("=== next i=" + i + " ===");
+                datum = mdbm.nextKey(itr);
+                Assert.assertNotNull(datum);
+                Assert.assertNotNull(datum.getData());
+                retStr = new String(datum.getData());
+                System.err.println(retStr);
+                sum += Integer.parseInt(retStr);
             }
-            for (int i = 0; i < max; i++) {
-                String k = Integer.toString(i);
-                String v = mdbm.fetchString(k);
-                Assert.assertNotNull(v);
+            System.err.println("=== expecting end ===");
+            datum = mdbm.nextKey(itr);
+            Assert.assertNull(datum);
+
+            Assert.assertEquals(sum, 45);
+        } finally {
+            if (null != mdbm)
+                mdbm.close();
+        }
+    }
+
+    @Test(dataProvider = "iterateMdbms")
+    public void testIterate(String path, int flags)
+            throws MdbmException, UnsupportedEncodingException {
+
+        MdbmInterface mdbm = null;
+        try {
+            mdbm = MdbmProvider.open(path, flags, 0755, 0, 0);
+
+            MdbmIterator itr = mdbm.iterator();
+            MdbmKvPair pair;
+            String kStr;
+            String vStr;
+            int kSum = 0;
+            int vSum = 0;
+
+            System.err.println("=== first ===");
+            pair = mdbm.first(itr);
+            Assert.assertNotNull(pair);
+            kStr = new String(pair.getKey().getData());
+            vStr = new String(pair.getValue().getData());
+            System.err.println(kStr + ", " + vStr);
+            kSum += Integer.parseInt(kStr);
+            vSum += Integer.parseInt(vStr);
+
+            for (int i = 1; i < iterationMax; i++) {
+                System.err.println("=== next i=" + i + " ===");
+                pair = mdbm.next(itr);
+                Assert.assertNotNull(pair);
+                kStr = new String(pair.getKey().getData());
+                vStr = new String(pair.getValue().getData());
+                System.err.println(kStr + ", " + vStr);
+                kSum += Integer.parseInt(kStr);
+                vSum += Integer.parseInt(vStr);
             }
-            String k = Integer.toString(max);
-            String v = mdbm.fetchString(k);
-            Assert.assertNull(v);
+            System.err.println("=== expecting end ===");
+            pair = mdbm.next(itr);
+            Assert.assertNull(pair);
+
+            Assert.assertEquals(kSum, 45);
+            Assert.assertEquals(vSum, 1045);
+
         } finally {
             if (null != mdbm)
                 mdbm.close();

--- a/src/java/src/test/java/com/yahoo/db/mdbm/TestV4.java
+++ b/src/java/src/test/java/com/yahoo/db/mdbm/TestV4.java
@@ -28,6 +28,12 @@ public class TestV4 extends TestSimpleMdbm {
     }
 
     @DataProvider
+    public Object[][] emptyMdbms() {
+        return new Object[][] {new Object[] {emptyMdbmV3Path,
+                Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR | Open.MDBM_O_CREAT,},};
+    }
+
+    @DataProvider
     public Object[][] iterateMdbms() {
         return new Object[][] {new Object[] {iteratorMdbmV3PathA,
                         Open.MDBM_CREATE_V3 | Open.MDBM_O_RDWR | Open.MDBM_O_CREAT,},};


### PR DESCRIPTION
In java implementation,
mdbm.first(iter) and mdbm.next(iter) do not work. They always return NULL.

This PR includes:
- fix the bug
- fix extra token in `jni_helper_defines.h`
- fix javadoc about first(), next(), firstKey(), nextKey()
- add unit tests to test first(), next(), firstKey(), nextKey()
