### PR TITLE
Fix compilation on macOS

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -22,6 +22,13 @@ COMP_FLAGS += -DALLOW_MLOCK_RESET
 # Overrides PARTITION_LOCK_CPU_MULTIPLIER
 #COMP_FLAGS += -DPARTITION_LOCK_COUNT=128
 
+ifeq ($(OS),Windows_NT)
+SHLIB_EXT := dll
+else ifeq ($(UNAME),Darwin)
+SHLIB_EXT := dylib
+else
+SHLIB_EXT := so
+endif
 
 ifeq ($(UNAME), Linux)
 # NOTE: we need to check RHEL6 or greater for robust-pthreads
@@ -135,6 +142,17 @@ endif
 LOCAL_LDADD = -L$(TOPDIR)/src/lib/$(OBJDIR)
 COMP_FLAGS +=  -g -O2 -I/usr/include -I$(INCDIR) -I$(TOPDIR)/include -I. -Wall -fPIC
 
+# OpenSSL is installed by default on macOS, but the headers are not.
+# Thus here we'll check for an installation of OpenSSL with Homebrew,
+# an unofficial but widely used package manager for macOS.
+ifeq ($(UNAME),Darwin)
+ifneq (,$(shell command -v brew))
+ifneq (,$(shell brew ls --versions openssl))
+COMP_FLAGS += -I$(shell brew --prefix openssl)/include
+endif # OpenSSL installed via Homebrew
+endif # Homebrew installed
+endif # Darwin
+
 # get gcc version (space-separated components)
 GCC_VER_SPC=$(shell gcc -dumpversion | tr '.' ' ')
 # turn it into an integer, zero-padding minor and patch versions to 4 digits
@@ -174,7 +192,7 @@ endif
 CFLAGS += $(COMP_FLAGS)
 CXXFLAGS += $(COMP_FLAGS)
 
-ifeq ($(CC),clang)
+ifneq (,$(shell $(CC) --version | grep clang))
   # allow for empty macro args, etc. under clang compiler
   CFLAGS += -std=gnu99
   CXXFLAGS += -std=c++11
@@ -194,7 +212,7 @@ $(OBJDIR)/%.o: %.cc
 #	$(CC) $(CFLAGS) $(PEDANTIC) -c $< -o $@
 
 # TODO ensure we have all gcov generated files
-CLEAN_OBJECTS=*.o *.d *.lib *.so.* *.xml *.gcov *.gcda
+CLEAN_OBJECTS:=*.o *.d *.lib *.$(SHLIB_EXT).* *.xml *.gcov *.gcda
 CLEAN_OB_DIRS=. $(OBJDIR_BASE) $(OBJDIR_PROF)
 .PHONY: clean-objs
 clean-objs:

--- a/src/cxx/Makefile
+++ b/src/cxx/Makefile
@@ -22,10 +22,10 @@ CPP_SOURCES=      \
 # TODO version library
 # TODO
 
-$(OBJDIR)/libmdbm_cxx.so : $(SOURCES:%.c=$(OBJDIR)/%.o) $(CPP_SOURCES:%.cc=$(OBJDIR)/%.o) $(HEADERS)
+$(OBJDIR)/libmdbm_cxx.$(SHLIB_EXT) : $(SOURCES:%.c=$(OBJDIR)/%.o) $(CPP_SOURCES:%.cc=$(OBJDIR)/%.o) $(HEADERS)
 	$(CC) $(CFLAGS) $(PEDANTIC) $(filter-out %.h %.hh,$^) $(LDADD) -fPIC -shared -o $@
 
-build-lib: $(OBJDIR)/libmdbm_cxx.so 
+build-lib: $(OBJDIR)/libmdbm_cxx.$(SHLIB_EXT)
 
 clean :: clean-objs
 

--- a/src/java/Makefile
+++ b/src/java/Makefile
@@ -9,7 +9,7 @@ CPP_SOURCES=      \
   com_yahoo_db_mdbm_internal_NativeMdbmAccess.cc
 
 
-LIBNAME=libmdbm_java.so
+LIBNAME=libmdbm_java.$(SHLIB_EXT)
 LIBVER=4
 SONAME=-Wl,-soname,$(LIBNAME).$(LIBVER)
 #-Wl,-rpath,$(DEFAULT_LIB_INSTALL_PATH)

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -23,7 +23,7 @@ CPP_SOURCES=      \
   multi_lock.cc
 
 
-LIBNAME=libmdbm.so
+LIBNAME=libmdbm.$(SHLIB_EXT)
 LIBVER=4
 ifeq ($(UNAME), Darwin)
 SONAME=-Wl,-install_name,$(LIBNAME).$(LIBVER)

--- a/src/tools/mash.cc
+++ b/src/tools/mash.cc
@@ -1882,7 +1882,7 @@ ProcessInputOption(const string &inputFile, bool outputToFile)
 int main(int argc, char** argv)
 {
     char pwdbuf[MAXPATHLEN];
-    if (getcwd(pwdbuf, MAXPATHLEN) > 0) {
+    if (getcwd(pwdbuf, MAXPATHLEN)) {
         PwdStr = pwdbuf;
     }
 


### PR DESCRIPTION
This PR does the following:
* Produce shared libraries with the proper extension for each platform rather than always .so
* Include OpenSSL headers installed via Homebrew on macOS
* Correct the check for Clang to enable the `-std=c++11` flag
* Fix a Clang comparison error between `char*` and `int`.

The Homebrew check is necessary here because Apple ships OpenSSL but not its headers, and when you install OpenSSL from Homebrew, it has to put the headers in a nonstandard location in order to avoid conflicts.

With this change I'm able to successfully build locally on macOS 10.12.

Edit: Fixes #85