### PR TITLE
Eliminate cast in mdbm_export_splitter.cc that is little endian dependent.

### DIFF
--- a/src/tools/mdbm_export_splitter.cc
+++ b/src/tools/mdbm_export_splitter.cc
@@ -90,8 +90,7 @@ getNumForHashCode(const char *optarg)
                           string("STL"),      string("MD5"),   string("SHA1"), 
                           string("JENKINS"),  string("HSIEH"), string() };
 
-    char (*pfunc)(char) = reinterpret_cast<char(*)(char)>(static_cast<int(*)(int)>(toupper));
-    transform(str.begin(), str.end(), str.begin(), pfunc);
+    transform(str.begin(), str.end(), str.begin(), [](char c) -> char { return toupper(c); });
     for (int hcode = smallestHashCode; nameList[hcode].empty() == false; ++hcode)
     {
         if (str.find(nameList[hcode]) != string::npos)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
